### PR TITLE
Use equal sign instead of space between option flag and value

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,16 +17,16 @@ module.exports = function (options, excludes) {
 		}
 
 		if (typeof val === 'string') {
-			args.push('--' + flag, val);
+			args.push('--' + flag + '=' + val);
 		}
 
 		if (typeof val === 'number' && isNaN(val) === false) {
-			args.push('--' + flag, '' + val);
+			args.push('--' + flag + '=' + ('' + val));
 		}
 
 		if (Array.isArray(val)) {
 			val.forEach(function (arrVal) {
-				args.push('--' + flag, arrVal);
+				args.push('--' + flag + '=' + arrVal);
 			});
 		}
 	});

--- a/readme.md
+++ b/readme.md
@@ -32,11 +32,11 @@ console.log(dargs(options, excludes));
 
 /*
 [
-	'--foo', 'bar',
+	'--foo=bar',
 	'--hello',
-	'--camel-case', '5',
-	'--multiple', 'value',
-	'--multiple', 'value2'
+	'--camel-case=5',
+	'--multiple=value',
+	'--multiple=value2'
 ]
 */
 ```

--- a/test.js
+++ b/test.js
@@ -17,11 +17,11 @@ describe('dargs()', function () {
 	it('convert options to cli flags', function () {
 		var actual = dargs(fixture);
 		var expected = [
-			'--a', 'foo',
+			'--a=foo',
 			'--b',
-			'--d', '5',
-			'--e', 'foo',
-			'--e', 'bar',
+			'--d=5',
+			'--e=foo',
+			'--e=bar',
 			'--camel-case-camel'
 		];
 		assert.deepEqual(actual, expected);
@@ -30,8 +30,8 @@ describe('dargs()', function () {
 	it('exclude options', function () {
 		var actual = dargs(fixture, ['b', 'e']);
 		var expected = [
-			'--a', 'foo',
-			'--d', '5',
+			'--a=foo',
+			'--d=5',
 			'--camel-case-camel'
 		];
 		assert.deepEqual(actual, expected);


### PR DESCRIPTION
With respect to https://github.com/gruntjs/grunt-contrib-sass/issues/140, https://github.com/gruntjs/grunt-contrib-sass/issues/142 and https://github.com/sass/sass/issues/1321,
use `=` instead of space flag and value delimiter, i.e. output `['--foo', 'bar']` becomes `['--foo=bar']`.
