### PR TITLE
Support short options and handle some edge cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,32 +1,63 @@
 'use strict';
+
+var constructOption = function (name, value) {
+	var prefix;
+	var delimiter;
+
+	if (name.length === 1) { // short option
+		prefix = '-';
+		delimiter = ' ';
+	} else { // long option
+		prefix = '--';
+		delimiter = '=';
+
+		// camelCase -> camel-case
+		name = name.replace(/[A-Z]/g, '-$&').toLowerCase();
+	}
+
+	return prefix + name + (value ? delimiter + value : '');
+};
+
 module.exports = function (options, excludes) {
 	var args = [];
 
-	Object.keys(options).forEach(function (key) {
-		var flag;
-		var val = options[key];
+	if (!Array.isArray(excludes)) {
+		excludes = [];
+	}
 
-		if (Array.isArray(excludes) && excludes.indexOf(key) !== -1) {
+	// exclude a special case which
+	// produces invalid/unexpected output
+	excludes.push('');
+
+	Object.keys(options).forEach(function (name) {
+		var val = options[name];
+
+		name = name.trim();
+
+		if (excludes.indexOf(name) !== -1) {
 			return;
 		}
 
-		flag = key.replace(/[A-Z]/g, '-$&').toLowerCase();
+		if (name.length === 1 && !/^[A-Za-z0-9]$/.test(name)) {
+			// that's an invalid (non-alphanumeric) short option
+			return;
+		}
 
 		if (val === true) {
-			args.push('--' + flag);
+			args.push(constructOption(name));
 		}
 
 		if (typeof val === 'string') {
-			args.push('--' + flag + '=' + val);
+			args.push(constructOption(name, val));
 		}
 
 		if (typeof val === 'number' && isNaN(val) === false) {
-			args.push('--' + flag + '=' + ('' + val));
+			args.push(constructOption(name, '' + val));
 		}
 
 		if (Array.isArray(val)) {
 			val.forEach(function (arrVal) {
-				args.push('--' + flag + '=' + arrVal);
+				args.push(constructOption(name, arrVal));
 			});
 		}
 	});

--- a/test.js
+++ b/test.js
@@ -3,13 +3,30 @@ var assert = require('assert');
 var dargs = require('./');
 
 var fixture = {
+	1: true,
+	'2': true,
 	a: 'foo',
+	aa: 'foo',
 	b: true,
+	bb: true,
 	c: false,
+	cc: false,
 	d: 5,
+	dd: 5,
 	e: ['foo', 'bar'],
+	ee: ['foo', 'bar'],
 	f: null,
+	ff: null,
 	g: undefined,
+	gg: undefined,
+	h: NaN,
+	hh: NaN,
+	X: 10,
+	'-': true,
+	'#': true,
+	'': true,
+	' trim ': true,
+	' ': 5,
 	camelCaseCamel: true
 };
 
@@ -17,21 +34,37 @@ describe('dargs()', function () {
 	it('convert options to cli flags', function () {
 		var actual = dargs(fixture);
 		var expected = [
-			'--a=foo',
-			'--b',
-			'--d=5',
-			'--e=foo',
-			'--e=bar',
+			'-1',
+			'-2',
+			'-a foo',
+			'--aa=foo',
+			'-b',
+			'--bb',
+			'-d 5',
+			'--dd=5',
+			'-e foo',
+			'-e bar',
+			'--ee=foo',
+			'--ee=bar',
+			'-X 10',
+			'--trim',
 			'--camel-case-camel'
 		];
 		assert.deepEqual(actual, expected);
 	});
 
 	it('exclude options', function () {
-		var actual = dargs(fixture, ['b', 'e']);
+		var actual = dargs(fixture, ['b', 'd', 'ee', 'aa']);
 		var expected = [
-			'--a=foo',
-			'--d=5',
+			'-1',
+			'-2',
+			'-a foo',
+			'--bb',
+			'--dd=5',
+			'-e foo',
+			'-e bar',
+			'-X 10',
+			'--trim',
 			'--camel-case-camel'
 		];
 		assert.deepEqual(actual, expected);


### PR DESCRIPTION
- Add support for short options (`-a`, `-P 18`, `-6`, etc) using `dargs({ a: true, P: 18, 6: true })`.
  Every single-character object key will be considered a short option if it is alphanumeric, or discarded otherwise, e.g. `'-': true` or `'@': 5` will be ignored.
- Trim option names and disallow empty string option names (see https://github.com/sindresorhus/dargs/issues/5).
- Add an option with a `NaN` value to tests.
