### PR TITLE
Allow users to pass option of unquote: true, to remove quotes from ...

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,10 +14,9 @@ var constructOption = function (name, value) {
 	return '--' + name + (value ? "='" + escape(value) + "'": '');
 };
 
-module.exports = function (options, excludes) {
+module.exports = function (options, excludes, preferences) {
 	var args = [];
-	var funcArgs = [].slice.call(arguments);
-	var unquote = (typeof funcArgs[2] === 'object' && funcArgs[2].unquote) ? true : false;
+	var unquote = (typeof preferences === 'object' && preferences.unquote) ? true : false;
 
 	Object.keys(options).forEach(function (name) {
 		var val = options[name];

--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,10 @@ var options = {
 
 var excludes = ['sad'];
 
+var preferences = {
+	unquote: true
+};
+
 console.log(dargs(options, excludes));
 
 /*
@@ -39,11 +43,8 @@ console.log(dargs(options, excludes));
 	"--multiple='value2'"
 ]
 */
-```
----
-#### Using `{unquote: true}`
-```
-console.log(dargs(options, excludes, {unquote: true}));
+
+console.log(dargs(options, excludes, preferences));
 /*
 [
 	"--foo=bar",
@@ -72,9 +73,11 @@ Type: `array`
 
 Keys to exclude.
 
-#### unquote
+#### preferences
 
 Type: `object`
+
+Key: `unquote` Default Value: `false` Type: `boolean`  
 
 To remove quotes from arguments
 

--- a/test.js
+++ b/test.js
@@ -14,7 +14,10 @@ var fixture = {
 	i: "let's try quotes",
 	j: ['with a space', '5', 'foo'],
 	camelCaseCamel: true
+};
 
+var preferences = {
+	unquote: true
 };
 
 describe('dargs()', function () {
@@ -47,7 +50,7 @@ describe('dargs()', function () {
 	});
 
 	it('returns unquoted', function () {
-		var actual = dargs(fixture, ['b', 'i', 'camelCaseCamel'], {unquote: true});
+		var actual = dargs(fixture, ['b', 'i', 'camelCaseCamel'], preferences);
 		var expected = [
 			"--a=foo",
 			"--d=5",


### PR DESCRIPTION
...strings without spaces and numbers

This allows for CLI arguments such as `--sourcemap=none` or `--style=compressed` as opposed to `--sourcemap='none'` or `--style='compressed'` which can throw errors in some executables.
