### PR TITLE
add param, allowing an 'includes' array

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,13 +5,17 @@ function createArg(key, val) {
 	return '--' + key + (val ? '=' + val : '');
 };
 
-module.exports = function (opts, excludes) {
+module.exports = function (opts, excludes, includes) {
 	var args = [];
 
 	Object.keys(opts).forEach(function (key) {
 		var val = opts[key];
 
 		if (Array.isArray(excludes) && excludes.indexOf(key) !== -1) {
+			return;
+		}
+
+		if (Array.isArray(includes) && includes.indexOf(key) === -1) {
 			return;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ var options = {
 };
 
 var excludes = ['sad'];
+var includes = ['camelCase', 'multiple', 'sad'];
 
 console.log(dargs(options, excludes));
 
@@ -39,12 +40,33 @@ console.log(dargs(options, excludes));
 	"--multiple=value2"
 ]
 */
-```
 
+console.log(dargs(options, excludes, includes));
+
+/*
+[
+	"--camel-case=5",
+	"--multiple=value",
+	"--multiple=value2"
+]
+*/
+
+
+console.log(dargs(options, [], includes));
+
+/*
+[
+	"--camel-case=5",
+	"--multiple=value",
+	"--multiple=value2",
+	"--sad=:("
+]
+*/
+```
 
 ## API
 
-### dargs(options, excludes)
+### dargs(options, excludes, includes)
 
 #### options
 
@@ -58,6 +80,11 @@ Type: `array`
 
 Keys to exclude.
 
+#### includes
+
+Type: `array`
+
+Keys to include. (if a key is in both `excludes` and `includes`, it will be excluded)
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -39,3 +39,25 @@ it('exclude options', function () {
 	];
 	assert.deepEqual(actual, expected);
 });
+
+it('includes options', function() {
+	var actual = dargs(fixture, [], ['a', 'c', 'd', 'e', 'camelCaseCamel']);
+	var expected = [
+		"--a=foo",
+		"--d=5",
+		"--e=foo",
+		"--e=bar",
+		"--camel-case-camel"
+	];
+	assert.deepEqual(actual, expected);
+});
+
+it('excludes and includes options', function() {
+	var actual = dargs(fixture, ['a', 'd'], ['a', 'c', 'd', 'e', 'camelCaseCamel']);
+	var expected = [
+		"--e=foo",
+		"--e=bar",
+		"--camel-case-camel"
+	];
+	assert.deepEqual(actual, expected);
+});


### PR DESCRIPTION
Sometimes it's nicer to specify the options we'd like to include.
The change is really minor but here's good example why it's useful:

``` javascript
var options = {
  apple: 'valueA',
  bread: 'valueB',
  carrot: 'valueC',
  dairy: 'valueD',
  eggs: 'valueE',
  figs: 'valueF',
  grapes: 'valueG',
};
// can now do this:
var args = dargs(options, [], ['apple', 'bread'])

// instead of this:
var args = dargs(options, ['carrot', 'dairy', 'eggs', 'figs', 'grapes'])
```

besides a few less characters, sometimes it's easier to specify what you need, instead of figuring out what you don't need.
