### PR TITLE
translate objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,19 @@
 'use strict';
 var numberIsNan = require('number-is-nan');
 
-function createArg(key, val) {
-	key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
+function createArg(key, val, cc) {
+	if(cc) {
+		key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
+	}
+
 	return '--' + key + (val ? '=' + val : '');
-};
+}
 
 module.exports = function (input, opts) {
 	var args = [];
 
 	opts = opts || {};
+	var cc = opts.translateCamelCase;
 
 	Object.keys(input).forEach(function (key) {
 		var val = input[key];
@@ -23,24 +27,24 @@ module.exports = function (input, opts) {
 		}
 
 		if (val === true) {
-			args.push(createArg(key));
+			args.push(createArg(key, null, cc));
 		}
 
 		if (val === false && !opts.ignoreFalse) {
-			args.push(createArg('no-' + key));
+			args.push(createArg('no-' + key, cc));
 		}
 
 		if (typeof val === 'string') {
-			args.push(createArg(key, val));
+			args.push(createArg(key, val, cc));
 		}
 
 		if (typeof val === 'number' && !numberIsNan(val)) {
-			args.push(createArg(key, '' + val));
+			args.push(createArg(key, '' + val, cc));
 		}
 
 		if (Array.isArray(val)) {
 			val.forEach(function (arrVal) {
-				args.push(createArg(key, arrVal));
+				args.push(createArg(key, arrVal, cc));
 			});
 		}
 	});

--- a/readme.md
+++ b/readme.md
@@ -99,12 +99,12 @@ Default: `false`
 
 Don't include `false` values. This is mostly useful when dealing with strict argument parsers that would throw on unknown arguments like `--no-foo`.
 
-##### translateCamelCase
+##### keepCamelCase
 
 Type: `boolean`  
 Default: `false`
 
-Translate camel case (someProp -> some-prop)
+Ignore camel case transformation
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,12 @@ Default: `false`
 
 Don't include `false` values. This is mostly useful when dealing with strict argument parsers that would throw on unknown arguments like `--no-foo`.
 
+##### translateCamelCase
+
+Type: `boolean`  
+Default: `false`
+
+Translate camel case (someProp -> some-prop)
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -90,7 +90,7 @@ test('excludes and includes options', function (t) {
 	t.end();
 });
 
-test('translateCamelCase option', function(t) {
+test('keepCamelCase option', function(t) {
 	var actual = dargs(fixture, {
 		keepCamelCase: true,
 		excludes: ['foo']

--- a/test.js
+++ b/test.js
@@ -13,7 +13,18 @@ var fixture = {
 	g: undefined,
 	h: 'with a space',
 	i: 'let\'s try quotes',
-	camelCaseCamel: true
+	camelCaseCamel: true,
+	foo: {
+		prop1: true,
+		prop2: {
+			test: [1,2,3],
+			test2: {
+				a: false,
+				b: true
+			}
+		},
+		prop3: 'bar'
+	}
 };
 
 test('convert options to cli flags', function (t) {
@@ -27,14 +38,19 @@ test('convert options to cli flags', function (t) {
 		'--e=bar',
 		'--h=with a space',
 		'--i=let\'s try quotes',
-		'--camel-case-camel'
+		'--camel-case-camel',
+		'--foo.prop1',
+		'--foo.prop2.test=1,2,3',
+		'--foo.prop2.test2.a',
+		'--foo.prop2.test2.b',
+		'--foo.prop3=bar'
 	];
 	t.assert(deepEqual(actual, expected));
 	t.end();
 });
 
 test('exclude options', function (t) {
-	var actual = dargs(fixture, {excludes: ['b', 'e', 'h', 'i']});
+	var actual = dargs(fixture, {excludes: ['b', 'e', 'h', 'i', 'foo']});
 	var expected = [
 		'--a=foo',
 		'--no-c',
@@ -61,7 +77,7 @@ test('includes options', function (t) {
 
 test('excludes and includes options', function (t) {
 	var actual = dargs(fixture, {
-		excludes: ['a', 'd'],
+		excludes: ['a', 'd', 'foo'],
 		includes: ['a', 'c', 'd', 'e', 'camelCaseCamel']
 	});
 	var expected = [
@@ -76,7 +92,8 @@ test('excludes and includes options', function (t) {
 
 test('translateCamelCase option', function(t) {
 	var actual = dargs(fixture, {
-		translateCamelCase: false
+		keepCamelCase: true,
+		excludes: ['foo']
 	});
 	var expected = [
 		'--a=foo',

--- a/test.js
+++ b/test.js
@@ -74,6 +74,25 @@ test('excludes and includes options', function (t) {
 	t.end();
 });
 
+test('translateCamelCase option', function(t) {
+	var actual = dargs(fixture, {
+		translateCamelCase: false
+	});
+	var expected = [
+		'--a=foo',
+		'--b',
+		'--no-c',
+		'--d=5',
+		'--e=foo',
+		'--e=bar',
+		'--h=with a space',
+		'--i=let\'s try quotes',
+		'--camelCaseCamel'
+	];
+	t.assert(deepEqual(actual, expected));
+	t.end();
+});
+
 test('option to ignore false values', function (t) {
 	var actual = dargs({foo: false}, {ignoreFalse: true});
 	t.assert(deepEqual(actual, []));


### PR DESCRIPTION
I needed to translate objects as well:

__Input:__
```js
{
    foo: {
        prop1: true,
        prop2: {
            test: [1,2,3],
            test2: {
                a: false,
                b: true
            }
        },
        prop3: 'bar'
    }
}
```

__Output:__
```js
[
    '--foo.prop1',
    '--foo.prop2.test=1,2,3',
    '--foo.prop2.test2.a',
    '--foo.prop2.test2.b',
    '--foo.prop3=bar'
]
```

Additionally I made the camel case transformation optional (see `keepCamelCase` option).