### PR TITLE
Add optional mapping of keys to short arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,10 @@ function match(arr, val) {
 	});
 }
 
+function createAliasArg(key, val) {
+	return '-' + key + (val ? ' ' + val : '');
+}
+
 module.exports = function (input, opts) {
 	var args = [];
 
@@ -19,6 +23,7 @@ module.exports = function (input, opts) {
 
 	Object.keys(input).forEach(function (key) {
 		var val = input[key];
+		var argFn = createArg;
 
 		if (Array.isArray(opts.excludes) && match(opts.excludes, key)) {
 			return;
@@ -28,25 +33,30 @@ module.exports = function (input, opts) {
 			return;
 		}
 
+		if (typeof opts.aliases === 'object' && opts.aliases[key]) {
+			key = opts.aliases[key];
+			argFn = createAliasArg;
+		}
+
 		if (val === true) {
-			args.push(createArg(key));
+			args.push(argFn(key, ''));
 		}
 
 		if (val === false && !opts.ignoreFalse) {
-			args.push(createArg('no-' + key));
+			args.push(argFn('no-' + key));
 		}
 
 		if (typeof val === 'string') {
-			args.push(createArg(key, val));
+			args.push(argFn(key, val));
 		}
 
 		if (typeof val === 'number' && !numberIsNan(val)) {
-			args.push(createArg(key, String(val)));
+			args.push(argFn(key, String(val)));
 		}
 
 		if (Array.isArray(val)) {
 			val.forEach(function (arrVal) {
-				args.push(createArg(key, arrVal));
+				args.push(argFn(key, arrVal));
 			});
 		}
 	});

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ const input = {
 
 const excludes = ['sad', /.*Kind$/];  // excludes and includes accept regular expressions
 const includes = ['camelCase', 'multiple', 'sad', /^pie.*/];
+const aliases = {file: 'f'};
 
 console.log(dargs(input, {excludes: excludes}));
 /*
@@ -61,8 +62,24 @@ console.log(dargs(input, {includes: includes}));
 	'--camel-case=5',
 	'--multiple=value',
 	'--multiple=value2',
-	'--sad=:(',
-	'--pie-kind=cherry'
+	'--pie-kind=cherry',
+	'--sad=:('
+]
+*/
+
+
+console.log(dargs({
+	foo: 'bar',
+	hello: true,
+	file: 'baz'
+}, {
+	aliases: aliases
+}));
+/*
+[
+	'--foo=bar',
+	'--hello',
+	'-f baz'
 ]
 */
 ```
@@ -93,6 +110,12 @@ Keys or regex of keys to exclude. Takes precedence over `includes`.
 Type: `array`
 
 Keys or regex of keys to include.
+
+##### aliases
+
+Type: `object`
+
+Maps keys in `input` to an aliased name. Matching keys are converted to options with a single dash ("-") in front of the aliased name and a space separating the aliased name from the value. Keys are still affected by `includes` and `excludes`.
 
 ##### ignoreFalse
 

--- a/test.js
+++ b/test.js
@@ -63,3 +63,28 @@ test('excludes and includes options', t => {
 test('option to ignore false values', t => {
 	t.same(fn({foo: false}, {ignoreFalse: true}), []);
 });
+
+test('aliases option', t => {
+	t.same(fn({a: 'foo', file: 'test'}, {
+		aliases: {file: 'f'}
+	}),
+		[
+			'--a=foo',
+			'-f test'
+		]);
+});
+
+test('includes and aliases options', t => {
+	t.same(fn(fixture, {
+		includes: ['a', 'c', 'd', 'e', 'camelCaseCamel'],
+		aliases: {a: 'a'}
+	}),
+		[
+			'-a foo',
+			'--no-c',
+			'--d=5',
+			'--e=foo',
+			'--e=bar',
+			'--camel-case-camel'
+		]);
+});


### PR DESCRIPTION
A generic solution to close #16. Allow the user to pass in
a `shortargs` object in the `options`. Each entry maps an
accepted value to a short argument. For example, passing

`dargs({'file': 'value'}, {shortargs: {'file': 'f'}})`

might produce an output like

`[ '-f value']`

This is nice because it allows you to work with some commands
that only support short arg versions of certain arguments (I
was working with `ctags -f`), while still encouraging you to
expose expressive, full word arguments to the end user.

Updated tests with usage alone and with `includes`, and docs
with examples and short description.