### PR TITLE
Treat elements of includes and excludes as globs instead of strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
 'use strict';
 var numberIsNan = require('number-is-nan');
+var minimatch = require('minimatch');
 
 function createArg(key, val) {
 	key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
 	return '--' + key + (val ? '=' + val : '');
 };
+
+function globMatch(globs, value){
+	return globs.some(function(glob) {
+		return minimatch(value, glob);
+	});
+}
 
 module.exports = function (input, opts) {
 	var args = [];
@@ -14,11 +21,11 @@ module.exports = function (input, opts) {
 	Object.keys(input).forEach(function (key) {
 		var val = input[key];
 
-		if (Array.isArray(opts.excludes) && opts.excludes.indexOf(key) !== -1) {
+		if (Array.isArray(opts.excludes) && globMatch(opts.excludes, key)) {
 			return;
 		}
 
-		if (Array.isArray(opts.includes) && opts.includes.indexOf(key) === -1) {
+		if (Array.isArray(opts.includes) && !globMatch(opts.includes, key)) {
 			return;
 		}
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "test": "node test.js"
   },
   "dependencies": {
-    "number-is-nan": "^1.0.0"
+    "number-is-nan": "^1.0.0",
+    "minimatch": "^3.0.0"
   },
   "devDependencies": {
     "array-equal": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,12 @@ var input = {
 	cake: false,                    // prepends `no-` before the key
 	camelCase: 5,                   // camelCase is slugged to `camel-case`
 	multiple: ['value', 'value2'],  // converted to multiple arguments
+	cakeKind: 'strawberry',
 	sad: ':('
 };
 
-var excludes = ['sad'];
-var includes = ['camelCase', 'multiple', 'sad'];
+var excludes = ['sad', '*Kind'];  // excludes and includes accept globs
+var includes = ['camelCase', 'multiple', 'sad', 'cake*'];
 
 console.log(dargs(input, {excludes: excludes}));
 /*
@@ -60,7 +61,8 @@ console.log(dargs(input, {includes: includes}));
 	'--camel-case=5',
 	'--multiple=value',
 	'--multiple=value2',
-	'--sad=:('
+	'--sad=:(',
+	'--cake-kind=strawberry'
 ]
 */
 ```
@@ -84,13 +86,13 @@ Type: `object`
 
 Type: `array`
 
-Keys to exclude. Takes precedence over `includes`.
+Keys or [globs](https://github.com/isaacs/minimatch#usage) to exclude. Takes precedence over `includes`.
 
 ##### includes
 
 Type: `array`
 
-Keys to include.
+Keys or [globs](https://github.com/isaacs/minimatch#usage) to include.
 
 ##### ignoreFalse
 

--- a/test.js
+++ b/test.js
@@ -34,7 +34,7 @@ test('convert options to cli flags', function (t) {
 });
 
 test('exclude options', function (t) {
-	var actual = dargs(fixture, {excludes: ['b', 'e', 'h', 'i']});
+	var actual = dargs(fixture, {excludes: ['b', '*e', 'h', 'i']});
 	var expected = [
 		'--a=foo',
 		'--no-c',
@@ -46,7 +46,7 @@ test('exclude options', function (t) {
 });
 
 test('includes options', function (t) {
-	var actual = dargs(fixture, {includes: ['a', 'c', 'd', 'e', 'camelCaseCamel']});
+	var actual = dargs(fixture, {includes: ['a', 'c', 'd', 'e', 'camelCase*']});
 	var expected = [
 		'--a=foo',
 		'--no-c',
@@ -62,7 +62,7 @@ test('includes options', function (t) {
 test('excludes and includes options', function (t) {
 	var actual = dargs(fixture, {
 		excludes: ['a', 'd'],
-		includes: ['a', 'c', 'd', 'e', 'camelCaseCamel']
+		includes: ['a', 'c', '+(d|e)', 'camelCaseCamel']
 	});
 	var expected = [
 		'--no-c',


### PR DESCRIPTION
Strings without glob characters like parentheses, "+", "-", and "*", will be matched with strict equality.  Strings with glob characters will now match any key provided by the user that matches the glob. The functionality is provided by the [minimatch](https://github.com/isaacs/minimatch) package, which is now included in the package.json.

For example, a user providing 'pythonKinds' would match the includes array `['*Kinds']`. This allows for cases where the first part of a command line argument is actually a hidden parameter. See `<LANG>-kinds` in ctags for an example.

Augmented `includes` and `excludes` tests to include globs, and updated the readme to include glob examples.

This closes #23.