### PR TITLE
make `includes` and `exludes` accept regexes in addition to strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,14 @@ function createArg(key, val) {
 	return '--' + key + (val ? '=' + val : '');
 };
 
+function match(arr, value){
+	return arr.some(function(toMatch) {
+		return toMatch instanceof RegExp
+			? toMatch.test(value)
+			: toMatch === value;
+	});
+}
+
 module.exports = function (input, opts) {
 	var args = [];
 
@@ -14,11 +22,11 @@ module.exports = function (input, opts) {
 	Object.keys(input).forEach(function (key) {
 		var val = input[key];
 
-		if (Array.isArray(opts.excludes) && opts.excludes.indexOf(key) !== -1) {
+		if (Array.isArray(opts.excludes) && match(opts.excludes, key)) {
 			return;
 		}
 
-		if (Array.isArray(opts.includes) && opts.includes.indexOf(key) === -1) {
+		if (Array.isArray(opts.includes) && !match(opts.includes, key)) {
 			return;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -23,11 +23,12 @@ var input = {
 	cake: false,                    // prepends `no-` before the key
 	camelCase: 5,                   // camelCase is slugged to `camel-case`
 	multiple: ['value', 'value2'],  // converted to multiple arguments
+	pieKind: 'cherry',
 	sad: ':('
 };
 
-var excludes = ['sad'];
-var includes = ['camelCase', 'multiple', 'sad'];
+var excludes = ['sad', /.*Kind$/];  // excludes and includes accept regular expressions
+var includes = ['camelCase', 'multiple', 'sad', /^pie.*/];
 
 console.log(dargs(input, {excludes: excludes}));
 /*
@@ -60,7 +61,8 @@ console.log(dargs(input, {includes: includes}));
 	'--camel-case=5',
 	'--multiple=value',
 	'--multiple=value2',
-	'--sad=:('
+	'--sad=:(',
+	'--pie-kind=cherry'
 ]
 */
 ```
@@ -84,13 +86,13 @@ Type: `object`
 
 Type: `array`
 
-Keys to exclude. Takes precedence over `includes`.
+Keys or regex of keys to exclude. Takes precedence over `includes`.
 
 ##### includes
 
 Type: `array`
 
-Keys to include.
+Keys or regex of keys to include.
 
 ##### ignoreFalse
 

--- a/test.js
+++ b/test.js
@@ -34,7 +34,7 @@ test('convert options to cli flags', function (t) {
 });
 
 test('exclude options', function (t) {
-	var actual = dargs(fixture, {excludes: ['b', 'e', 'h', 'i']});
+	var actual = dargs(fixture, {excludes: ['b', /^e$/, 'h', 'i']});
 	var expected = [
 		'--a=foo',
 		'--no-c',
@@ -46,7 +46,7 @@ test('exclude options', function (t) {
 });
 
 test('includes options', function (t) {
-	var actual = dargs(fixture, {includes: ['a', 'c', 'd', 'e', 'camelCaseCamel']});
+	var actual = dargs(fixture, {includes: ['a', 'c', 'd', 'e', /^camelCase.*/]});
 	var expected = [
 		'--a=foo',
 		'--no-c',
@@ -62,7 +62,7 @@ test('includes options', function (t) {
 test('excludes and includes options', function (t) {
 	var actual = dargs(fixture, {
 		excludes: ['a', 'd'],
-		includes: ['a', 'c', 'd', 'e', 'camelCaseCamel']
+		includes: ['a', 'c', /^[de]$/, 'camelCaseCamel']
 	});
 	var expected = [
 		'--no-c',


### PR DESCRIPTION
The `includes` and `excludes` options now accept and handle regular
expressions in additions to strings. This makes including and excluding
keys much more flexible.

For example, a user providing 'pythonKinds' would match the includes
array `[/.*Kinds/]`. This allows for cases where the first part of a
command line argument is actually a hidden parameter. See `<LANG>-kinds`
in ctags for an example.

Augmented `includes` and `excludes` tests to include regular expressions,
and updated readme to include regex examples.

-

Fixes #23.