### PR TITLE
Allow the user to configure the separator between command line arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 var numberIsNan = require('number-is-nan');
 
-function createArg(key, val) {
+function createArg(key, val, separator) {
 	key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
-	return '--' + key + (val ? '=' + val : '');
+	return '--' + key + (val ? separator + val : '');
 }
 
 function match(arr, val) {
@@ -20,6 +20,8 @@ module.exports = function (input, opts) {
 	var args = [];
 
 	opts = opts || {};
+
+	var separator = opts.separator || '=';
 
 	Object.keys(input).forEach(function (key) {
 		var val = input[key];
@@ -47,16 +49,16 @@ module.exports = function (input, opts) {
 		}
 
 		if (typeof val === 'string') {
-			args.push(argFn(key, val));
+			args.push(argFn(key, val, separator));
 		}
 
 		if (typeof val === 'number' && !numberIsNan(val)) {
-			args.push(argFn(key, String(val)));
+			args.push(argFn(key, String(val), separator));
 		}
 
 		if (Array.isArray(val)) {
 			val.forEach(function (arrVal) {
-				args.push(argFn(key, arrVal));
+				args.push(argFn(key, arrVal, separator));
 			});
 		}
 	});

--- a/readme.md
+++ b/readme.md
@@ -82,6 +82,21 @@ console.log(dargs({
 	'-f baz'
 ]
 */
+
+// You can override the default separator
+console.log(dargs(input, {
+	includes: includes,
+	separator: ' '
+}));
+/*
+[
+	'--camel-case 5',
+	'--multiple value',
+	'--multiple value2',
+	'--sad :(',
+	'--pie-kind cherry'
+]
+*/
 ```
 
 ## API
@@ -111,11 +126,21 @@ Type: `array`
 
 Keys or regex of keys to include.
 
+<<<<<<< ea3815451ef5a2b46ac199f19e0ce1ee71b940fe
 ##### aliases
 
 Type: `object`
 
 Maps keys in `input` to an aliased name. Matching keys are converted to options with a single dash ("-") in front of the aliased name and a space separating the aliased name from the value. Keys are still affected by `includes` and `excludes`.
+=======
+
+##### separator
+
+Type: `String`  
+Default: `=`
+
+String to separate keys from values in command-line arguments.
+>>>>>>> Allow the user to configure the separator between command line arguments
 
 ##### ignoreFalse
 

--- a/test.js
+++ b/test.js
@@ -28,6 +28,22 @@ test('convert options to cli flags', t => {
 	]);
 });
 
+test('separator options', t => {
+	t.same(fn(fixture, {
+		separator: ' '
+	}), [
+		'--a foo',
+		'--b',
+		'--no-c',
+		'--d 5',
+		'--e foo',
+		'--e bar',
+		'--h with a space',
+		'--i let\'s try quotes',
+		'--camel-case-camel'
+	]);
+});
+
 test('exclude options', t => {
 	t.same(fn(fixture, {excludes: ['b', /^e$/, 'h', 'i']}), [
 		'--a=foo',


### PR DESCRIPTION
Tries to fix #25 in a general way. Instead of the user being able to toggle the
'=' sign on and off, they can set the separator to any value. For example,
`dargs({foo: bar}, {separator: ' '})` produces `['foo bar']`.

Not sure if this is overkill, or less intuitive than the binary option.

Added tests and updated readme to reflect changes.