### PR TITLE
Add useEquals options to swap "=" for " "

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 'use strict';
 var numberIsNan = require('number-is-nan');
 
-function createArg(key, val) {
+function createArg(key, val, separator) {
 	key = key.replace(/[A-Z]/g, '-$&').toLowerCase();
-	return '--' + key + (val ? '=' + val : '');
+	return '--' + key + (val ? separator + val : '');
 }
 
 function match(arr, val) {
@@ -20,6 +20,8 @@ module.exports = function (input, opts) {
 	var args = [];
 
 	opts = opts || {};
+
+	var separator = opts.useEquals === false ? ' ' : '=';
 
 	Object.keys(input).forEach(function (key) {
 		var val = input[key];
@@ -47,16 +49,16 @@ module.exports = function (input, opts) {
 		}
 
 		if (typeof val === 'string') {
-			args.push(argFn(key, val));
+			args.push(argFn(key, val, separator));
 		}
 
 		if (typeof val === 'number' && !numberIsNan(val)) {
-			args.push(argFn(key, String(val)));
+			args.push(argFn(key, String(val), separator));
 		}
 
 		if (Array.isArray(val)) {
 			val.forEach(function (arrVal) {
-				args.push(argFn(key, arrVal));
+				args.push(argFn(key, arrVal, separator));
 			});
 		}
 	});

--- a/readme.md
+++ b/readme.md
@@ -117,6 +117,22 @@ Type: `object`
 
 Maps keys in `input` to an aliased name. Matching keys are converted to options with a single dash ("-") in front of the aliased name and a space separating the aliased name from the value. Keys are still affected by `includes` and `excludes`.
 
+##### useEquals
+
+Type: `boolean`
+Default: `true`
+
+Setting to `false` switches the separator in generated commands from an equals sign ("=") to a single space (" "). For example:
+
+```js
+console.log(dargs({foo: 'bar'}, {useEquals: false}));
+/*
+[
+    '--foo bar'
+]
+*/
+```
+
 ##### ignoreFalse
 
 Type: `boolean`  

--- a/test.js
+++ b/test.js
@@ -28,6 +28,22 @@ test('convert options to cli flags', t => {
 	]);
 });
 
+test('useEquals options', t => {
+	t.same(fn(fixture, {
+		useEquals: false
+	}), [
+		'--a foo',
+		'--b',
+		'--no-c',
+		'--d 5',
+		'--e foo',
+		'--e bar',
+		'--h with a space',
+		'--i let\'s try quotes',
+		'--camel-case-camel'
+	]);
+});
+
 test('exclude options', t => {
 	t.same(fn(fixture, {excludes: ['b', /^e$/, 'h', 'i']}), [
 		'--a=foo',


### PR DESCRIPTION
Close #25 by allowing the user to generate a single space (" ") in their argument instead of an equals sign ("=") when required. For example:

```js
console.log(dargs({foo: 'bar'}, {useEquals: false}))
/*
[
  '--foo bar'
]
*/
```
 
Updated readme and added test to reflect changes.