### PR TITLE
Add support for an "_" key which appends values to the end of the args list

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ function createAliasArg(key, val) {
 
 module.exports = function (input, opts) {
 	var args = [];
+	var extraArgs = [];
 
 	opts = opts || {};
 
@@ -38,6 +39,15 @@ module.exports = function (input, opts) {
 		if (typeof opts.aliases === 'object' && opts.aliases[key]) {
 			key = opts.aliases[key];
 			argFn = createAliasArg;
+		}
+
+		if (key === '_') {
+			if (!Array.isArray(val)) {
+				throw new TypeError('special key \'_\' expected to be an Array, found a(n) ' + (typeof val) + '.');
+			}
+
+			extraArgs = val;
+			return;
 		}
 
 		if (val === true) {
@@ -61,6 +71,10 @@ module.exports = function (input, opts) {
 				args.push(argFn(key, arrVal, separator));
 			});
 		}
+	});
+
+	extraArgs.forEach(function (extraArgVal) {
+		args.push(String(extraArgVal));
 	});
 
 	return args;

--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ $ npm install --save dargs
 const dargs = require('dargs');
 
 const input = {
+	_: ['some', 'option'],          // each value in '_' will be appended to the end of the generated argument list, imitating minimist
 	foo: 'bar',
 	hello: true,                    // results in only the key being used
 	cake: false,                    // prepends `no-` before the key
@@ -39,7 +40,9 @@ console.log(dargs(input, {excludes: excludes}));
 	'--no-cake',
 	'--camel-case=5',
 	'--multiple=value',
-	'--multiple=value2'
+	'--multiple=value2',
+	'some',
+	'option'
 ]
 */
 

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ import test from 'ava';
 import fn from './';
 
 const fixture = {
+	_: ['some', 'option'],
 	a: 'foo',
 	b: true,
 	c: false,
@@ -24,8 +25,14 @@ test('convert options to cli flags', t => {
 		'--e=bar',
 		'--h=with a space',
 		'--i=let\'s try quotes',
-		'--camel-case-camel'
+		'--camel-case-camel',
+		'some',
+		'option'
 	]);
+});
+
+test('raises a TypeError if  \'_\' value is not an Array', t => {
+	t.throws(fn.bind(fn, {a: 'foo', _: 'baz'}), TypeError);
 });
 
 test('useEquals options', t => {
@@ -40,7 +47,9 @@ test('useEquals options', t => {
 		'--e bar',
 		'--h with a space',
 		'--i let\'s try quotes',
-		'--camel-case-camel'
+		'--camel-case-camel',
+		'some',
+		'option'
 	]);
 });
 
@@ -49,7 +58,9 @@ test('exclude options', t => {
 		'--a=foo',
 		'--no-c',
 		'--d=5',
-		'--camel-case-camel'
+		'--camel-case-camel',
+		'some',
+		'option'
 	]);
 });
 


### PR DESCRIPTION
Add support for an "\_" key which appends values to the end of the argument array.  This imitates [`minimist`](https://github.com/substack/minimist#example), which parses free arguments into array of values keyed by "\_". This should close #19.

If the value of the "\_" key is not an Array, it will be added to the end of the args list. Otherwise, each value in the "\_" Array will be pushed to onto the end of the args list.

Updated tests and readme to reflect changes.