### PR TITLE
Handle `--` separator and the args and options that follow

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ const match = (arr, val) => arr.some(x => x instanceof RegExp ? x.test(val) : x 
 module.exports = (input, opts) => {
 	const args = [];
 	let extraArgs = [];
+	let separatedArgs = [];
 
 	opts = Object.assign({
 		useEquals: true
@@ -50,6 +51,15 @@ module.exports = (input, opts) => {
 			pushArg = makeAliasArg;
 		}
 
+		if (key === '--') {
+			if (!Array.isArray(val)) {
+				throw new TypeError(`Expected key \`--\` to be Array, got ${typeof val}`);
+			}
+
+			separatedArgs = val;
+			return;
+		}
+
 		if (key === '_') {
 			if (!Array.isArray(val)) {
 				throw new TypeError(`Expected key \`_\` to be Array, got ${typeof val}`);
@@ -83,6 +93,14 @@ module.exports = (input, opts) => {
 	});
 
 	for (const x of extraArgs) {
+		args.push(String(x));
+	}
+
+	if (separatedArgs.length > 0) {
+		args.push('--');
+	}
+
+	for (const x of separatedArgs) {
 		args.push(String(x));
 	}
 

--- a/test.js
+++ b/test.js
@@ -33,7 +33,7 @@ test('convert options to cli flags', t => {
 		'other',
 		'args',
 		'-z',
-		'--camelCaseOpt' // case unaffected for separated options
+		'--camelCaseOpt' // Case unaffected for separated options
 	]);
 });
 

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@ import m from './';
 
 const fixture = {
 	_: ['some', 'option'],
+	'--': ['other', 'args', '-z', '--camelCaseOpt'],
 	a: 'foo',
 	b: true,
 	c: false,
@@ -27,12 +28,21 @@ test('convert options to cli flags', t => {
 		'--i=let\'s try quotes',
 		'--camel-case-camel',
 		'some',
-		'option'
+		'option',
+		'--',
+		'other',
+		'args',
+		'-z',
+		'--camelCaseOpt' // case unaffected for separated options
 	]);
 });
 
 test('raises a TypeError if  \'_\' value is not an Array', t => {
 	t.throws(m.bind(m, {a: 'foo', _: 'baz'}), TypeError);
+});
+
+test('raises a TypeError if  \'--\' value is not an Array', t => {
+	t.throws(m.bind(m, {a: 'foo', '--': 'baz'}), TypeError);
 });
 
 test('useEquals options', t => {
@@ -49,7 +59,12 @@ test('useEquals options', t => {
 		'--i', 'let\'s try quotes',
 		'--camel-case-camel',
 		'some',
-		'option'
+		'option',
+		'--',
+		'other',
+		'args',
+		'-z',
+		'--camelCaseOpt'
 	]);
 });
 
@@ -60,7 +75,12 @@ test('exclude options', t => {
 		'--d=5',
 		'--camel-case-camel',
 		'some',
-		'option'
+		'option',
+		'--',
+		'other',
+		'args',
+		'-z',
+		'--camelCaseOpt'
 	]);
 });
 
@@ -128,6 +148,11 @@ test('camelCase option', t => {
 		'--i=let\'s try quotes',
 		'--camelCaseCamel',
 		'some',
-		'option'
+		'option',
+		'--',
+		'other',
+		'args',
+		'-z',
+		'--camelCaseOpt'
 	]);
 });


### PR DESCRIPTION
Hi, dargs does not handle the `--` separator from a parsed minimist result: https://github.com/substack/minimist#var-argv--parseargsargs-opts

Arguments and options after the `--` separator are left unparsed and put into a positional array, much like `_: []` args. So, if the key is detected, append them to the dargs.