### PR TITLE
Add `shortFlag` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,17 +31,17 @@ declare namespace dargs {
 		useEquals?: boolean;
 
 		/**
-		Setting this to `true` makes possible short flags to be returned correctly, meaning that a single character flag like `{a: true}` to become `-a`.
-		When this is set to `false` for `{a: true}` it will result in `--a` instead.
+		Make a single character option key `{a: true}` become a short flag `-a` instead of `--a`.
 
 		@default false
 
 		@example
 		```
 		console.log(dargs({a: true}, {shortFlag: true}));
-		// ['-a']
+		//=> ['-a']
+
 		console.log(dargs({a: true}));
-		// ['--a']
+		//=> ['--a']
 		```
 		*/
 		shortFlag?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare namespace dargs {
 		```
 		console.log(dargs({a: true}, {shortFlag: true}));
 		// ['-a']
-		console.log(dargs({a: true}, {shortFlag: false}));
+		console.log(dargs({a: true}));
 		// ['--a']
 		```
 		*/

--- a/index.d.ts
+++ b/index.d.ts
@@ -31,6 +31,22 @@ declare namespace dargs {
 		useEquals?: boolean;
 
 		/**
+		Setting this to `true` makes possible short flags to be returned correctly, meaning that a single character flag like `{a: true}` to become `-a`.
+		When this is set to `false` for `{a: true}` it will result in `--a` instead.
+
+		@default false
+
+		@example
+		```
+		console.log(dargs({a: true}, {shortFlag: true}));
+		// ['-a']
+		console.log(dargs({a: true}, {shortFlag: false}));
+		// ['--a']
+		```
+		*/
+		shortFlag?: boolean;
+
+		/**
 		Exclude `false` values. Can be useful when dealing with strict argument parsers that throw on unknown arguments like `--no-foo`.
 
 		@default false

--- a/index.js
+++ b/index.js
@@ -13,11 +13,12 @@ const dargs = (input, options) => {
 	}, options);
 
 	const makeArg = (key, value) => {
-		key =
-			'--' +
-			(options.allowCamelCase ?
-				key :
-				key.replace(/[A-Z]/g, '-$&').toLowerCase());
+		const prefix = options.allowSingleFlags && key.length === 1 ? '-' : '--';
+		const theKey = (options.allowCamelCase ?
+			key :
+			key.replace(/[A-Z]/g, '-$&').toLowerCase());
+
+		key = prefix + theKey;
 
 		if (options.useEquals) {
 			args.push(key + (value ? `=${value}` : ''));

--- a/index.js
+++ b/index.js
@@ -9,11 +9,12 @@ const dargs = (input, options) => {
 	let separatedArgs = [];
 
 	options = Object.assign({
-		useEquals: true
+		useEquals: true,
+		shortFlag: false
 	}, options);
 
 	const makeArg = (key, value) => {
-		const prefix = options.allowSingleFlags && key.length === 1 ? '-' : '--';
+		const prefix = options.shortFlag && key.length === 1 ? '-' : '--';
 		const theKey = (options.allowCamelCase ?
 			key :
 			key.replace(/[A-Z]/g, '-$&').toLowerCase());

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError} from 'tsd';
-import dargs = require('.');
+import * as dargs from '.';
 
 const input = {
 	_: ['some', 'option'],
@@ -20,6 +20,7 @@ expectType<string[]>(dargs(input, {excludes}));
 expectType<string[]>(dargs(input, {includes}));
 expectType<string[]>(dargs(input, {aliases}));
 expectType<string[]>(dargs(input, {useEquals: false}));
+expectType<string[]>(dargs(input, {shortFlag: true}));
 expectType<string[]>(dargs(input, {ignoreFalse: true}));
 expectType<string[]>(dargs(input, {allowCamelCase: true}));
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,5 +1,5 @@
 import {expectType, expectError} from 'tsd';
-import * as dargs from '.';
+import dargs = require('.');
 
 const input = {
 	_: ['some', 'option'],

--- a/readme.md
+++ b/readme.md
@@ -137,6 +137,22 @@ console.log(dargs({foo: 'bar'}, {useEquals: false}));
 */
 ```
 
+##### shortFlag
+
+Type: `boolean`<br>
+Default: `false`
+
+Setting this to `true` makes possible short flags to be returned correctly, meaning that a single character flag like `{a: true}` to become `-a`. When this is set to `false` for `{a: true}` it will result in `--a` instead.
+
+###### Example
+
+```js
+console.log(dargs({a: true}, {shortFlag: true}))
+// ['-a']
+console.log(dargs({a: true}))
+// ['--a']
+```
+
 ##### ignoreFalse
 
 Type: `boolean`<br>

--- a/readme.md
+++ b/readme.md
@@ -142,15 +142,16 @@ console.log(dargs({foo: 'bar'}, {useEquals: false}));
 Type: `boolean`<br>
 Default: `false`
 
-Setting this to `true` makes possible short flags to be returned correctly, meaning that a single character flag like `{a: true}` to become `-a`. When this is set to `false` for `{a: true}` it will result in `--a` instead.
+Make a single character option key `{a: true}` become a short flag `-a` instead of `--a`.
 
 ###### Example
 
 ```js
-console.log(dargs({a: true}, {shortFlag: true}))
-// ['-a']
-console.log(dargs({a: true}))
-// ['--a']
+console.log(dargs({a: true}, {shortFlag: true}));
+//=> ['-a']
+
+console.log(dargs({a: true}));
+//=> ['--a']
 ```
 
 ##### ignoreFalse

--- a/test.js
+++ b/test.js
@@ -164,3 +164,14 @@ test('camelCase option', t => {
 		'--camelCaseOpt'
 	]);
 });
+
+test('allowSingleFlags: true option', t => {
+	t.deepEqual(dargs({a: 123, b: 'foo', foo: 'bar', camelCaseCamel: true}, {
+		allowSingleFlags: true
+	}), [
+		'-a=123',
+		'-b=foo',
+		'--foo=bar',
+		'--camel-case-camel'
+	]);
+});

--- a/test.js
+++ b/test.js
@@ -167,7 +167,7 @@ test('camelCase option', t => {
 
 test('allowSingleFlags: true option', t => {
 	t.deepEqual(dargs({a: 123, b: 'foo', foo: 'bar', camelCaseCamel: true}, {
-		allowSingleFlags: true
+		shortFlag: true
 	}), [
 		'-a=123',
 		'-b=foo',

--- a/test.js
+++ b/test.js
@@ -165,7 +165,7 @@ test('camelCase option', t => {
 	]);
 });
 
-test('allowSingleFlags: true option', t => {
+test('shortFlag option', t => {
 	t.deepEqual(dargs({a: 123, b: 'foo', foo: 'bar', camelCaseCamel: true}, {
 		shortFlag: true
 	}), [


### PR DESCRIPTION
Resolves #32 


Let me know if that option name is okay, or if you don't want to have an option at all, which in turn will mean a major bump.

**Example**

```js
const dargs = require('dargs');

const argv = require('minimist')(process.argv.slice(2));

console.log(dargs(argv, { allowSingleFlags: true }));
// => ['-a=123', '--foo=bar']

// Old behavior and still default one
console.log(dargs(argv));
// => ['--a=123', '--foo=bar']
```