### PR TITLE
add transformers option for preprocessing values

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,9 +72,32 @@ declare namespace dargs {
 		console.log(dargs({fooBar: 'baz'}, {allowCamelCase: true}));
 		//=> ['--fooBar', 'baz']
 		```
-		*/
+		 */
 		allowCamelCase?: boolean;
+
+		/**
+		 A map of transformers for preprocessing the value before dargs decides how to serialize it.
+
+		 @default {}
+
+		 @example
+		```
+		import dargs = require('dargs');
+
+		console.log(dargs({fooBar: 3}, {
+			transformers: {
+				fooBar: source => source * 2
+			}
+		}));
+		//=> ['--foo-bar', '6']
+		```
+		 */
+		transformers?: Transformers;
 	}
+}
+
+interface Transformers {
+	[key: string]: {(source: any): any};
 }
 
 /**

--- a/index.js
+++ b/index.js
@@ -11,7 +11,16 @@ const dargs = (object, options) => {
 	options = {
 		useEquals: true,
 		shortFlag: true,
+		transformers: {},
 		...options
+	};
+
+	const transformValue = (key, value) => {
+		if (typeof options.transformers[key] === 'function') {
+			return options.transformers[key](value);
+		}
+
+		return value;
 	};
 
 	const makeArguments = (key, value) => {
@@ -78,6 +87,8 @@ const dargs = (object, options) => {
 			extraArguments = value;
 			continue;
 		}
+
+		value = transformValue(key, value);
 
 		if (value === true) {
 			pushArguments(key, '');

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -23,6 +23,8 @@ expectType<string[]>(dargs(object, {useEquals: false}));
 expectType<string[]>(dargs(object, {shortFlag: true}));
 expectType<string[]>(dargs(object, {ignoreFalse: true}));
 expectType<string[]>(dargs(object, {allowCamelCase: true}));
+expectType<string[]>(dargs(object, {transformers: {something: source => "yep"}}));
 
 expectError(dargs({_: 'foo'}));
 expectError(dargs({'--': 'foo'}));
+expectError<string[]>(dargs(object, {transformers: {something: "nope"}}));

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,15 @@ console.log(dargs({
 	'-f', 'baz'
 ]
 */
+
+console.log(dargs({
+	foo: 3
+}, {transformers: {foo: source => source * 2}}));
+/*
+[
+	'--foo=6'
+]
+*/
 ```
 
 
@@ -178,6 +187,20 @@ console.log(dargs({fooBar: 'baz'}, {allowCamelCase: true}));
 //=> ['--fooBar', 'baz']
 ```
 
+##### transformers
+
+A map of transformers for preprocessing the value before dargs decides how to serialize it.
+
+```js
+const dargs = require('dargs');
+
+console.log(dargs({fooBar: 3}, {
+    transformers: {
+        fooBar: source => source * 2
+    }
+}));
+//=> ['--foo-bar', '6']
+```
 
 ---
 

--- a/test.js
+++ b/test.js
@@ -175,3 +175,14 @@ test('shortFlag option', t => {
 		'--camel-case-camel'
 	]);
 });
+
+test('transformers option', t => {
+	t.deepEqual(dargs({first: 123, second: {some: 'object'}}, {
+		transformers: {
+			second: source => `'${JSON.stringify(source)}'`
+		}
+	}), [
+		'--first=123',
+		'--second=\'{"some":"object"}\''
+	]);
+});


### PR DESCRIPTION
Adds an option to provide a map of transformers so you can preprocess the values for certain keys.

The examples added to the docs are quite simplistic but the real-world use case I have is where some items on the object we are passing to `dargs` are themselves objects, and we want the value for passing to the CLI to be the result of `JSON.stringify` on that.

This might be too far in terms of configurability (and to be fair you could just preprocess outside of `dargs`) but wasn't sure if there should be any default behaviour for objects (currently, anything that's not a boolean, string, number or array will be skipped over silently).