### PR TITLE
Add `ignoreTrue` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -50,6 +50,13 @@ export interface Options {
 	readonly shortFlag?: boolean;
 
 	/**
+	Exclude `true` values. Can be useful when dealing with argument parsers that only expect negated arguments like `--no-foo`.
+
+	@default false
+	*/
+	readonly ignoreTrue?: boolean;
+
+	/**
 	Exclude `false` values. Can be useful when dealing with strict argument parsers that throw on unknown arguments like `--no-foo`.
 
 	@default false

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ export default function dargs(object, options) {
 			continue;
 		}
 
-		if (value === true) {
+		if (value === true && !options.ignoreTrue) {
 			pushArguments(key, '');
 		}
 

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -21,6 +21,7 @@ expectType<string[]>(dargs(object, {includes}));
 expectType<string[]>(dargs(object, {aliases}));
 expectType<string[]>(dargs(object, {useEquals: false}));
 expectType<string[]>(dargs(object, {shortFlag: true}));
+expectType<string[]>(dargs(object, {ignoreTrue: true}));
 expectType<string[]>(dargs(object, {ignoreFalse: true}));
 expectType<string[]>(dargs(object, {allowCamelCase: true}));
 

--- a/readme.md
+++ b/readme.md
@@ -151,6 +151,13 @@ console.log(dargs({a: true}, {shortFlag: false}));
 //=> ['--a']
 ```
 
+##### ignoreTrue
+
+Type: `boolean`\
+Default: `false`
+
+Exclude `true` values. Can be useful when dealing with argument parsers that only expect negated arguments like `--no-foo`.
+
 ##### ignoreFalse
 
 Type: `boolean`\

--- a/test.js
+++ b/test.js
@@ -113,6 +113,10 @@ test('excludes and includes options', t => {
 	]);
 });
 
+test('option to ignore true values', t => {
+	t.deepEqual(dargs({foo: true}, {ignoreTrue: true}), []);
+});
+
 test('option to ignore false values', t => {
 	t.deepEqual(dargs({foo: false}, {ignoreFalse: true}), []);
 });


### PR DESCRIPTION
Some tools have features enabled by default, and therefore only accept negated flags (like --no-foo).

With `ignoreTrue`, `true` values like `{foo: true}` will be ignored.